### PR TITLE
Fix subreddit link in bot message

### DIFF
--- a/commands/bot/jfc.js
+++ b/commands/bot/jfc.js
@@ -11,7 +11,7 @@ export default {
 Join the [JellyfinCommunity Discord](https://discord.gg/v7P9CAvCKZ) for support, discussions, and more!
 
 **Reddit**  
-Visit the [r/Jellyfin subreddit](https://www.reddit.com/r/JellyfinCommunity/) for news, tips, and community content.`,
+Visit the [r/JellyfinCommunity subreddit](https://www.reddit.com/r/JellyfinCommunity/) for news, tips, and community content.`,
             allowedMentions: { users: [] }
         });
     },


### PR DESCRIPTION
Clarification to make clear that the link leads to JellyfinCommunity and should not be confused with the official subreddit